### PR TITLE
前夜祭チケットのボタン追加&now-on-saleの公開

### DIFF
--- a/2018okinawa/assets/css/custom.css
+++ b/2018okinawa/assets/css/custom.css
@@ -63,6 +63,11 @@
   border: 2px solid #379bc6;
 }
 
+.button a.btn-before-night-party {
+  color:  #008051;
+  border: 2px solid #008051;
+}
+
 /* About */
 
 #about dl {

--- a/2018okinawa/data/buttons.json5
+++ b/2018okinawa/data/buttons.json5
@@ -5,7 +5,7 @@
     { type: "ticket",             label: "一般・学生チケット",         blank: true, url: "https://passmarket.yahoo.co.jp/event/show/detail/01dewpz7g87m.html" },
     { type: "personal-sponsor",             label: "個人スポンサーチケット",         blank: true, url: "https://passmarket.yahoo.co.jp/event/show/detail/01h74dz7g92i.html" },
     { type: "bus",             label: "バスチケット",         blank: true, url: "https://passmarket.yahoo.co.jp/event/show/detail/017xe4z7g99k.html" },
-    //{ type: "before-night-party", label: "前夜祭チケット",             blank: true,  url: "https://passmarket.yahoo.co.jp/event/show/detail/01an8myrc3t0.html" },
+    { type: "before-night-party", label: "前夜祭チケット",             blank: true,  url: "https://passmarket.yahoo.co.jp/event/show/detail/01eqykz85hir.html" },
     //{ type: "after-party",        label: "懇親会チケット",             blank: true,  url: "https://passmarket.yahoo.co.jp/event/show/detail/01pp1jyrc3uq.html" },
     //{ type: "sponsor",             label: "スポンサーメニュー",         blank: true, url: "./sponsor_menu.html" },
     //{ type: "before-night-party-lt",               label: "前夜祭LTソン LT発表者登録(要前夜祭チケット)",           blank: true,  url: "https://atnd.org/events/88820" },

--- a/2018okinawa/data/tickets.json5
+++ b/2018okinawa/data/tickets.json5
@@ -1,15 +1,15 @@
 {
   "ticket-groups": [
-    //{
-    //  name: "YAPC::Okinawa 2018 ONNASON 03/03 前夜祭",
-    //  tickets: [
-    //    {
-    //      id:    "01an8myrc3t0",
-    //      name:  "前夜祭参加チケット",
-    //      class: "sold-out"
-    //    },
-    //  ],
-    //},
+    {
+      name: "YAPC::Okinawa 2018 ONNASON 03/02 前夜祭",
+      tickets: [
+        {
+          id:    "01eqykz85hir",
+          name:  "前夜祭参加チケット",
+          class: "now-on-sale"
+        },
+      ],
+    },
     {
       name: "YAPC::Okinawa 2018 ONNASON 03/03",
       tickets: [

--- a/docs/2018okinawa/assets/css/custom.css
+++ b/docs/2018okinawa/assets/css/custom.css
@@ -63,6 +63,11 @@
   border: 2px solid #379bc6;
 }
 
+.button a.btn-before-night-party {
+  color:  #008051;
+  border: 2px solid #008051;
+}
+
 /* About */
 
 #about dl {

--- a/docs/2018okinawa/index.html
+++ b/docs/2018okinawa/index.html
@@ -31,7 +31,7 @@
 <link rel="stylesheet" href="./assets/css/bootstrap.css?cachebuster=454994">
 <link rel="stylesheet" href="./assets/css/font-awesome.css?cachebuster=454944">
 <link rel="stylesheet" href="./assets/css/fonts.css?cachebuster=454998">
-<link rel="stylesheet" href="./assets/css/custom.css?cachebuster=454947">
+<link rel="stylesheet" href="./assets/css/custom.css?cachebuster=454935">
 <link rel="stylesheet" href="https://cdn.rawgit.com/michalsnik/aos/2.1.1/dist/aos.css">
 <link rel="stylesheet" media="(max-width: 899px)" href="./assets/css/html.sp.css?cachebuster=455012">
 <link rel="stylesheet" media="(min-width: 900px)" href="./assets/css/html.pc.css?cachebuster=454958">
@@ -84,6 +84,7 @@
           <li><a href="https://passmarket.yahoo.co.jp/event/show/detail/01dewpz7g87m.html" class="btn btn-ticket btn-lg"  target="_blank">&#x4E00;&#x822C;&#x30FB;&#x5B66;&#x751F;&#x30C1;&#x30B1;&#x30C3;&#x30C8;</a></li>
           <li><a href="https://passmarket.yahoo.co.jp/event/show/detail/01h74dz7g92i.html" class="btn btn-personal-sponsor btn-lg"  target="_blank">&#x500B;&#x4EBA;&#x30B9;&#x30DD;&#x30F3;&#x30B5;&#x30FC;&#x30C1;&#x30B1;&#x30C3;&#x30C8;</a></li>
           <li><a href="https://passmarket.yahoo.co.jp/event/show/detail/017xe4z7g99k.html" class="btn btn-bus btn-lg"  target="_blank">&#x30D0;&#x30B9;&#x30C1;&#x30B1;&#x30C3;&#x30C8;</a></li>
+          <li><a href="https://passmarket.yahoo.co.jp/event/show/detail/01eqykz85hir.html" class="btn btn-before-night-party btn-lg"  target="_blank">&#x524D;&#x591C;&#x796D;&#x30C1;&#x30B1;&#x30C3;&#x30C8;</a></li>
   </ul>
   </div><!--  / .button /  -->
   </div><!--  / .section /  -->
@@ -141,6 +142,15 @@
   <div class="section" id="tickets" data-aos="fade-up" data-aos-duration="2000">
   <h3 class="title">Tickets</h3>
     <div class="body">
+      <h4>YAPC::Okinawa 2018 ONNASON 03/02 &#x524D;&#x591C;&#x796D;</h4>
+      <ul>
+        <li class="ticket">
+          <b class="now-on-sale">
+            <a href="http://passmarket.yahoo.co.jp/event/show/detail/01eqykz85hir.html" target="_blank">&#x524D;&#x591C;&#x796D;&#x53C2;&#x52A0;&#x30C1;&#x30B1;&#x30C3;&#x30C8;</a>
+          </b>
+          <em class="annotation now-on-sale">発売中!!</em>
+        </li>
+      </ul> <br />
       <h4>YAPC::Okinawa 2018 ONNASON 03/03</h4>
       <ul>
         <li class="ticket">

--- a/docs/2018okinawa/individual-sponsors.html
+++ b/docs/2018okinawa/individual-sponsors.html
@@ -31,7 +31,7 @@
 <link rel="stylesheet" href="./assets/css/bootstrap.css?cachebuster=454994">
 <link rel="stylesheet" href="./assets/css/font-awesome.css?cachebuster=454944">
 <link rel="stylesheet" href="./assets/css/fonts.css?cachebuster=454998">
-<link rel="stylesheet" href="./assets/css/custom.css?cachebuster=454947">
+<link rel="stylesheet" href="./assets/css/custom.css?cachebuster=454935">
 <link rel="stylesheet" href="https://cdn.rawgit.com/michalsnik/aos/2.1.1/dist/aos.css">
 <link rel="stylesheet" media="(max-width: 899px)" href="./assets/css/html.sp.css?cachebuster=455012">
 <link rel="stylesheet" media="(min-width: 900px)" href="./assets/css/html.pc.css?cachebuster=454958">

--- a/docs/2018okinawa/sponsor_menu.html
+++ b/docs/2018okinawa/sponsor_menu.html
@@ -29,7 +29,7 @@
   <link rel="stylesheet" href="./assets/css/bootstrap.css?cachebuster=454994">
   <link rel="stylesheet" href="./assets/css/font-awesome.css?cachebuster=454944">
   <link rel="stylesheet" href="./assets/css/fonts.css?cachebuster=454998">
-  <link rel="stylesheet" href="./assets/css/custom.css?cachebuster=454947">
+  <link rel="stylesheet" href="./assets/css/custom.css?cachebuster=454935">
   <link rel="stylesheet" href="https://cdn.rawgit.com/michalsnik/aos/2.1.1/dist/aos.css">
   <link rel="stylesheet" media="(max-width: 899px)" href="./assets/css/sponsor_menu.sp.css?cachebuster=455008">
   <link rel="stylesheet" media="(min-width: 900px)" href="./assets/css/sponsor_menu.pc.css?cachebuster=454969">

--- a/docs/2018okinawa/sponsors.html
+++ b/docs/2018okinawa/sponsors.html
@@ -31,7 +31,7 @@
 <link rel="stylesheet" href="./assets/css/bootstrap.css?cachebuster=454994">
 <link rel="stylesheet" href="./assets/css/font-awesome.css?cachebuster=454944">
 <link rel="stylesheet" href="./assets/css/fonts.css?cachebuster=454998">
-<link rel="stylesheet" href="./assets/css/custom.css?cachebuster=454947">
+<link rel="stylesheet" href="./assets/css/custom.css?cachebuster=454935">
 <link rel="stylesheet" href="https://cdn.rawgit.com/michalsnik/aos/2.1.1/dist/aos.css">
 <link rel="stylesheet" media="(max-width: 899px)" href="./assets/css/html.sp.css?cachebuster=455012">
 <link rel="stylesheet" media="(min-width: 900px)" href="./assets/css/html.pc.css?cachebuster=454958">

--- a/docs/2018okinawa/staff.html
+++ b/docs/2018okinawa/staff.html
@@ -31,7 +31,7 @@
 <link rel="stylesheet" href="./assets/css/bootstrap.css?cachebuster=454994">
 <link rel="stylesheet" href="./assets/css/font-awesome.css?cachebuster=454944">
 <link rel="stylesheet" href="./assets/css/fonts.css?cachebuster=454998">
-<link rel="stylesheet" href="./assets/css/custom.css?cachebuster=454947">
+<link rel="stylesheet" href="./assets/css/custom.css?cachebuster=454935">
 <link rel="stylesheet" href="https://cdn.rawgit.com/michalsnik/aos/2.1.1/dist/aos.css">
 <link rel="stylesheet" media="(max-width: 899px)" href="./assets/css/html.sp.css?cachebuster=455012">
 <link rel="stylesheet" media="(min-width: 900px)" href="./assets/css/html.pc.css?cachebuster=454958">

--- a/docs/2018okinawa/talks.html
+++ b/docs/2018okinawa/talks.html
@@ -31,7 +31,7 @@
 <link rel="stylesheet" href="./assets/css/bootstrap.css?cachebuster=454994">
 <link rel="stylesheet" href="./assets/css/font-awesome.css?cachebuster=454944">
 <link rel="stylesheet" href="./assets/css/fonts.css?cachebuster=454998">
-<link rel="stylesheet" href="./assets/css/custom.css?cachebuster=454947">
+<link rel="stylesheet" href="./assets/css/custom.css?cachebuster=454935">
 <link rel="stylesheet" href="https://cdn.rawgit.com/michalsnik/aos/2.1.1/dist/aos.css">
 <link rel="stylesheet" media="(max-width: 899px)" href="./assets/css/html.sp.css?cachebuster=455012">
 <link rel="stylesheet" media="(min-width: 900px)" href="./assets/css/html.pc.css?cachebuster=454958">

--- a/docs/2018okinawa/timetable.html
+++ b/docs/2018okinawa/timetable.html
@@ -31,7 +31,7 @@
 <link rel="stylesheet" href="./assets/css/bootstrap.css?cachebuster=454994">
 <link rel="stylesheet" href="./assets/css/font-awesome.css?cachebuster=454944">
 <link rel="stylesheet" href="./assets/css/fonts.css?cachebuster=454998">
-<link rel="stylesheet" href="./assets/css/custom.css?cachebuster=454947">
+<link rel="stylesheet" href="./assets/css/custom.css?cachebuster=454935">
 <link rel="stylesheet" href="https://cdn.rawgit.com/michalsnik/aos/2.1.1/dist/aos.css">
 <link rel="stylesheet" media="(max-width: 899px)" href="./assets/css/html.sp.css?cachebuster=455012">
 <link rel="stylesheet" media="(min-width: 900px)" href="./assets/css/html.pc.css?cachebuster=454958">


### PR DESCRIPTION
2018okinawa/assets/css/custom.cssに以下を追記
```
.button a.btn-before-night-party {
  color:  #008051;
  border: 2px solid #008051;
}
```
buttons.json5, tickets.json5での前夜祭チケットのコメントアウトを外しました。
確認宜しくお願いします。