### PR TITLE
Job Boardのタイトル部分にidを追加

### DIFF
--- a/2022online/index.mustache
+++ b/2022online/index.mustache
@@ -43,7 +43,7 @@
         {{/guestSpeakers}}
       </ul>
 
-      <h2 class="mt-16 md:mt-32 mb-10 md:mb-20">
+      <h2 class="mt-16 md:mt-32 mb-10 md:mb-20" id="job-board">
         <span class="px-1 py-1 text-3xl font-bold tracking-wider text-white bg-tint">
         Job Board
         </span>


### PR DESCRIPTION
URLに `#job-board`で跳べると便利なはず…