### PR TITLE
lang属性をjaにする

### DIFF
--- a/2024hiroshima/src/partial/header.ejs
+++ b/2024hiroshima/src/partial/header.ejs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="jp">
+<html lang="ja">
 
 <head>
 	<meta charset="UTF-8">


### PR DESCRIPTION
`lang`属性の値はBCP 47に基づいているため、日本語を指定する場合は`ja`が正確です。`jp`はISO国コードであり、言語コードではありません。

不正確：
```html
<html lang="jp">
```

正確：
```html
<html lang="ja">
```
